### PR TITLE
Fix: doesn't boot in Safari 10

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,3 +1,4 @@
+(function() {
 let canvas
 ,   stage
 ,   player
@@ -505,3 +506,4 @@ const loop = now => {
     }
 }
 loop(lastFrame)
+})()


### PR DESCRIPTION
Safari wouldn't let you make a global variable named `stage` because there is a DOM element with `id="stage"`. Yeah, DOM elements are accessible in JavaScript that way. Safari is being strict with the error "Cannot declare a let variable twice".

This solution is don't use global variables.